### PR TITLE
Switch from tox build wrapper to charmcraft.yaml overrides

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install tox & poetry
         run: |
           pipx install tox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v21.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v22.0.0
 
   unit-test:
     name: Unit test charm
@@ -40,7 +40,7 @@ jobs:
         path:
         - .
         - ./tests/integration/relations/opensearch_provider/application-charm/
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v22.0.0
     with:
       path-to-charm-directory: ${{ matrix.path }}
       cache: true
@@ -51,7 +51,7 @@ jobs:
       - lint
       - unit-test
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v21.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v22.0.0
     with:
       artifact-prefix: packed-charm-cache-true
       cloud: lxd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
   #   timeout-minutes: 60
   #   steps:
   #     - name: Checkout
-  #       uses: actions/checkout@v3
+  #       uses: actions/checkout@v4
   #       with:
   #         fetch-depth: 0
   #     - name: Release charm libraries

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,13 +34,13 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v22.0.0
 
   release:
     name: Release charm
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v21.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v22.0.0
     with:
       channel: latest/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,9 +10,6 @@ bases:
       - name: "ubuntu"
         channel: "22.04"
 parts:
-  files:
-    plugin: dump
-    source: .
   charm:
     override-build: |
       rustup default stable

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -13,21 +13,15 @@ parts:
   files:
     plugin: dump
     source: .
-    prime:
-      - charm_version
-      - workload_version
   charm:
-    override-pull: |
-      craftctl default
-      if [[ ! -f requirements.txt ]]
-      then
-          echo 'ERROR: Use "tox run -e build-dev" instead of calling "charmcraft pack" directly' >&2
-          exit 1
-      fi
     override-build: |
       rustup default stable
+      # Convert subset of poetry.lock to requirements.txt
+      curl -sSL https://install.python-poetry.org | python3 -
+      /root/.local/bin/poetry export --only main,charm-libs --output requirements.txt
       craftctl default
     charm-strict-dependencies: true
+    charm-requirements: [requirements.txt]
     charm-entrypoint: src/charm.py
     build-snaps:
       - rustup

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ set_env =
     # Workaround for https://github.com/python-poetry/poetry/issues/6958
     POETRY_INSTALLER_PARALLEL = false
 allowlist_externals =
+    {[testenv]allowlist_externals}
     # Set the testing host before starting the lxd cloud
     sudo
     sysctl

--- a/tox.ini
+++ b/tox.ini
@@ -19,32 +19,6 @@ set_env =
 allowlist_externals =
     poetry
 
-[testenv:build-{production,dev,wrapper}]
-# Wrap `charmcraft pack`
-pass_env =
-    CI
-    GH_TOKEN
-allowlist_externals =
-    {[testenv]allowlist_externals}
-    charmcraft
-    charmcraftcache
-    mv
-commands_pre =
-    # TODO charm versioning: Remove
-    # Workaround to add unique identifier (git hash) to charm version while specification
-    # DA053 - Charm versioning
-    # (https://docs.google.com/document/d/1Jv1jhWLl8ejK3iJn7Q3VbCIM9GIhp8926bgXpdtx-Sg/edit?pli=1)
-    # is pending review.
-    python -c 'import pathlib; import shutil; import subprocess; git_hash=subprocess.run(["git", "describe", "--always", "--dirty"], capture_output=True, check=True, encoding="utf-8").stdout; file = pathlib.Path("charm_version"); shutil.copy(file, pathlib.Path("charm_version.backup")); version = file.read_text().strip(); file.write_text(f"{version}+{git_hash}")'
-
-    poetry export --only main,charm-libs --output requirements.txt
-commands =
-    build-production: charmcraft pack {posargs}
-    build-dev: charmcraftcache pack {posargs}
-commands_post =
-    mv requirements.txt requirements-last-build.txt
-    mv charm_version.backup charm_version
-
 [testenv:format]
 description = Apply coding style standards to code
 commands_pre =
@@ -95,8 +69,6 @@ set_env =
     # Workaround for https://github.com/python-poetry/poetry/issues/6958
     POETRY_INSTALLER_PARALLEL = false
 allowlist_externals =
-    {[testenv:build-wrapper]allowlist_externals}
-
     # Set the testing host before starting the lxd cloud
     sudo
     sysctl
@@ -106,9 +78,5 @@ commands_pre =
 
     # Set the testing host before starting the lxd cloud
     sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
-
-    {[testenv:build-wrapper]commands_pre}
 commands =
     poetry run pytest -v --tb native --log-cli-level=INFO -s --ignore={[vars]tests_path}/unit/ {posargs}
-commands_post =
-    {[testenv:build-wrapper]commands_post}


### PR DESCRIPTION
As defined by https://github.com/canonical/data-platform-workflows/releases/tag/v22.0.0 to support charmcraftcache-hub
