### PR TITLE
Set the charm name

### DIFF
--- a/terraform/charm/main.tf
+++ b/terraform/charm/main.tf
@@ -6,7 +6,7 @@ resource "juju_application" "wazuh_indexer" {
   model = var.model
 
   charm {
-    name     = var.app_name
+    name     = "wazuh-indexer"
     channel  = var.channel
     revision = var.revision
     base     = var.base


### PR DESCRIPTION
The charm name must be defined statically as it references the charm on charmhub.