### PR TITLE
Restrict access for Wazuh context

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_users.py
+++ b/lib/charms/opensearch/v0/opensearch_users.py
@@ -331,7 +331,8 @@ class OpenSearchUserManager:
                     "backend_roles": [AdminUser],
                     "opendistro_security_roles": [
                         "security_rest_api_access",
-                        "all_access",
+                        # "all_access", #  Wazuh: would prevent password changes for admin
+                        #                  as all_access is reserved
                     ],
                     "description": "Admin user",
                 },

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -148,7 +148,6 @@ async def test_actions_get_admin_password(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.skip("Wazuh: to be implemented")
 async def test_actions_rotate_admin_password(ops_test: OpsTest) -> None:
     """Test the rotation and change of admin password."""
     leader_ip = await get_leader_unit_ip(ops_test)


### PR DESCRIPTION
# Context

The opensearch charm gives `admin` user full access by adding it to the `all_access` policy.
On a fresh Wazuh installation `admin` does not have this role.

The opensearch charm does not protect `all_access` from changes through the API (`reserved: false` in `opensearch-security/roles_mapping.yml`).
On a fresh Wazuh installation `all_access` is protected from changes through the API (`reserved: true` in `opensearch-security/roles_mapping.yml`).

# Problem

When `admin` has the `all_access` role, it inherits the protection from the role. It means that if the role cannot be edited through the API (`reserved: true`), the admin attributes cannot either.

This is why the admin password rotation test was failing in wazuh charm.

# Solutions

## Option 1: remove admin `all_access`

Applying the principle of least privilege, we remove `admin` from `all_access` role. This way the `admin` password can be rotated through the API.

## Option 2: unprotect `all_access`

By changing `reserved` to `false` for `all_access` in `roles_mapping.yml`, we would allow changes on the role and associated users through the API.

# Proposal

Go for option 1 as it doesn't seem to block any other tests and we don't have use cases where admin requires `all_access` for now.

We would have to change to option 2 in the future if we need admin to perform some additional actions.