### PR TITLE
Re-check Vale and fix errors

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,0 +1,5 @@
+bool
+failover
+Failover
+MLCommons
+repurposing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,5 +112,5 @@ juju integrate self-signed-certificates wazuh-indexer
 **Note:** The TLS settings shown here are for self-signed-certificates, which are not recommended for production clusters. The TLS Certificates Operator offers a variety of configurations. Read more on the self-signed-certificates Operator [here](https://charmhub.io/self-signed-certificates).
 
 
-## Canonical Contributor Agreement
+## Canonical contributor agreement
 Canonical welcomes contributions to the Charmed Template Operator. Please check out our [contributor agreement](https://ubuntu.com/legal/contributors) if you're interested in contributing to the solution.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 # Wazuh Indexer Operator
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
+
 [![Charmhub](https://charmhub.io/wazuh-indexer/badge.svg)](https://charmhub.io/wazuh-indexer)
 [![Release](https://github.com/canonical/wazuh-indexer-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/wazuh-indexer-operator/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/wazuh-indexer-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/wazuh-indexer-operator/actions/workflows/ci.yaml)
@@ -52,14 +55,14 @@ sudo sysctl -p
 juju model-config --file=./cloudinit-userdata.yaml
 ```
 
-### Basic Usage
+### Basic usage
 To deploy a single unit of Wazuh Indexer using its default configuration.
 
 ```shell
 juju deploy wazuh-indexer --channel=4.11/edge
 ```
 
-## Relations / Integrations
+## Relations / integrations
 
 The relevant provided [relations](https://juju.is/docs/olm/relations) of Charmed Wazuh Indexer are:
 

--- a/docs/explanation/e-cryptography.md
+++ b/docs/explanation/e-cryptography.md
@@ -15,13 +15,15 @@ Every artifact included in the snaps is verified against its SHA-256 or SHA-512 
 Charmed OpenSearch sources are stored in:
 
 * GitHub repositories for snaps, rocks and charms
-* LaunchPad repositories for the OpenSearch and OpenSearch Dashboards upstream fork used for building their respective distributions
+* Launchpad repositories for the OpenSearch and OpenSearch Dashboards upstream fork used for building their respective distributions
 
-### LaunchPad
+### Launchpad
 
 Distributions are built using private repositories only, hosted as part of the [SOSS namespace](https://launchpad.net/soss) to eventually integrate with Canonical’s standard process for fixing CVEs. Branches associated with releases are mirrored to a public repository, hosted in the [Data Platform namespace](https://launchpad.net/~data-platform) to also provide the community with the patched source code.
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ### GitHub
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 All OpenSearch artifacts built by Canonical are published and released programmatically using release pipelines implemented via GitHub Actions. Distributions are published as both GitHub and LaunchPad releases via the [central-uploader repository](https://github.com/canonical/central-uploader), while charms, snaps and rocks are published using the workflows of their respective repositories.
 
@@ -59,7 +61,7 @@ Authentication to OpenSearch Dashboards is based on HTTP basic authentication wi
 
 The file needs to be readable and writable by root (as it is created by the charm) and readable by the snap_daemon user running the OpenSearch server snap commands.
 
-### OpenSearch Inter-node authentication
+### OpenSearch inter-node authentication
 
 Authentication among nodes is based on the HTTP basic authentication with username and password. Usernames and passwords are exchanged via peer relations.
 

--- a/docs/explanation/e-security.md
+++ b/docs/explanation/e-security.md
@@ -75,6 +75,6 @@ Charmed OpenSearch provides native integration with the [Canonical Observability
 
 For instructions, see the [How to integrate the Charmed OpenSearch deployment with COS](https://charmhub.io/opensearch/docs/h-monitoring) guide.
 
-## Additional Resources
+## Additional resources
 
 For details on the cryptography used by Charmed OpenSearch, see the [Cryptography](https://discourse.charmhub.io/t/charmed-opensearch-explanation-cryptography/17243) explanation page.

--- a/docs/how-to/h-attached-storage.md
+++ b/docs/how-to/h-attached-storage.md
@@ -63,7 +63,7 @@ opensearch/2  opensearch-data/2  filesystem  opensearch-pool  2.0 GiB  attached
 For more details, [refer to Juju storage management documentation](https://juju.is/docs/juju/manage-storage).
 
 
-## Re-using Disks Use-Cases
+## Re-using disks use-cases
 
 OpenSearch does have a set of APIs and mechanisms to detect the existence of previous data on a given node and how to interact with that data. Most notable mechanisms are: (i) the `/_dangling` API, [as described in the upstream docs](https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/); and (ii) the `opensearch-node` CLI that allows operators to clean up portions of the metadata in the *used disk* before re-attaching to the cluster.
 
@@ -77,7 +77,7 @@ The following scenarios will be considered:
 
 The main concern in these cases is the management of the cluster metadata and the status of the previous indices.
 
-### Same Cluster Scenario
+### Same cluster scenario
 
 We can check which volumes are currently available to be reattached:
 ```
@@ -134,7 +134,7 @@ $ curl -sk -u admin:$PASSWORD https://$IP:9200/_cat/nodes
 10.81.173.167 29 98 16 3.75 5.59 4.99 dim cluster_manager,data,ingest,ml * opensearch-1.f1a
 ```
 
-### Different Cluster Scenarios
+### Different cluster scenarios
 
 In these cases, the cluster has been removed and the application will be redeployed reusing these disks in part or in total. In all of the following cases, the `opensearch-node` CLI will be needed to clean up portions of the metadata.
 
@@ -227,7 +227,7 @@ The cluster will be correctly form a new UUID. It is possible to also add more u
 
 
 
-## Dangling Indices
+## Dangling indices
 
 Now, the *used disk*  is successfully mounted to the cluster. The next step is to check for indices that  did not exist in the cluster. That can be done using the `/_dangling` API. To understand n more details how to list and recover dangling indices, refer to the [OpenSearch documentation on this API](https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/).
 

--- a/docs/how-to/h-deploy-lxd.md
+++ b/docs/how-to/h-deploy-lxd.md
@@ -16,7 +16,9 @@ If you are a beginner to OpenSearch or Juju and are looking for a more comprehen
 
 ---
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## Disable IPv6 on LXD
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 Juju does not support IPv6 addresses with LXD. To set the network bridge to have no IPv6 addresses, run the following command after initializing LXD:
 ```

--- a/docs/how-to/h-integrate.md
+++ b/docs/how-to/h-integrate.md
@@ -10,7 +10,7 @@ This guide will walk you through integrating your charm with OpenSearch via the 
     - [Add the `opensearch_client` interface to your charm](#add-the-opensearch_client-interface-to-your-charm)
     - [Import the database interface libraries and define database event handlers](#import-the-database-interface-libraries-and-define-database-event-handlers)
     - [Integrate the client application with OpenSearch](#integrate-the-client-application-with-opensearch)
-  - [Integrate an application outside of juju with OpenSearch](#integrate-an-application-outside-of-juju-with-opensearch)
+  - [Integrate an application outside of Juju with OpenSearch](#integrate-an-application-outside-of-juju-with-opensearch)
     - [Deploy the `data-integrator` charm](#deploy-the-data-integrator-charm)
     - [Relate the `data-integrator` charm to an OpenSearch cluster](#relate-the-data-integrator-charm-to-an-opensearch-cluster)
     - [Remove the client integration](#remove-the-client-integration)
@@ -52,7 +52,7 @@ Then, instantiate the `OpenSearchRequires` class in your charm. The class takes 
 - `charm`: The charm instance
 - `relation_name`: The name of the relation to which to connect. This should match the name of the relation defined in the `metadata.yaml` file (`opensearch` in the example above).
 - `index`: The name of the index the client application will connect to.
-- `extra_user_roles`: A string containing the additional roles to assign to the user. This is optional and defualts to `None`.
+- `extra_user_roles`: A string containing the additional roles to assign to the user. This is optional and defaults to `None`.
 - `addional_secret_fields`: A list of additional secret fields to be shared with the client application. This is optional and defaults to an empty list.
 
 ```python
@@ -89,7 +89,7 @@ To remove the integration, run:
 juju remove-relation opensearch <application>
 ```
 
-## Integrate an application outside of juju with OpenSearch
+## Integrate an application outside of Juju with OpenSearch
 
 The `data-integrator` charm is a bare-bones charm that allows for central management of database users, providing support for different kinds of data platform products (e.g. MongoDB, MySQL, PostgreSQL, Kafka, etc) with a consistent, opinionated and robust user experience.
 

--- a/docs/how-to/h-large-deployment.md
+++ b/docs/how-to/h-large-deployment.md
@@ -21,7 +21,7 @@ When deploying OpenSearch at scale, it is important to understand the `roles` th
 
 Amongst the [multiple roles](https://opensearch.org/docs/latest/tuning-your-cluster/) supported by OpenSearch, two notable roles are especially crucial for a successful cluster formation:
 
-- `cluster_manager`: assigned to nodes responsible for handling cluster-wide operations such as creating and deleting indices, managing shards, and rebalancing data across the cluster. Every cluster has a single `cluster_manager` node elected as the master node among the `cluster_manager` eligible nodes.
+- `cluster_manager`: assigned to nodes responsible for handling cluster-wide operations such as creating and deleting indices, managing shards, and rebalancing data across the cluster. Every cluster has a single `cluster_manager` node elected as the main node among the `cluster_manager` eligible nodes.
 - `data`: assigned to nodes which store and perform data-related operations like indexing and searching. Data nodes hold the shards that contain the indexed data. Data nodes can also be configured to perform ingest and transform operations. 
 In charmed OpenSearch, data nodes can optionally be further classified into tiers - to allow for defining [index lifecycle management policies](https://opensearch.org/docs/latest/im-plugin/ism/index/): 
   - `data.hot`

--- a/docs/how-to/h-minor-upgrade.md
+++ b/docs/how-to/h-minor-upgrade.md
@@ -37,7 +37,7 @@ To upgrade your OpenSearch cluster, follow these steps:
 1. Collect all necessary pre-upgrade information. It will be required for the rollback (if requested). **Do NOT skip this step**.
 2. (optional) Scale-up: The new sacrificial unit will be the first to be updated, and will simplify the rollback procedure in case of the upgrade failure.
 3. Prepare the “Charmed OpenSearch” Juju application for the in-place upgrade. See the step description below for all the technical details the charm executes.
-4. Upgrade: Only one app unit will be upgraded once started. In case of failure, roll back with juju refresh.
+4. Upgrade: Only one app unit will be upgraded once started. In case of failure, roll back with `juju refresh`.
 5. Resume upgrade: The upgrade can be resumed if the upgrade of the first unit is successful. All units in an app will be executed sequentially from the highest to lowest unit number.
 6. (optional) Consider [rolling back](/t/14142) in case of disaster. Please [inform and include us](https://app.element.io/#/room/#charmhub-data-platform:ubuntu.com) in your case scenario troubleshooting to trace the source of the issue and prevent it in the future.
 7. (optional) Scale back: Remove no longer necessary units created in step 2 (if any).

--- a/docs/how-to/h-monitoring-enable.md
+++ b/docs/how-to/h-monitoring-enable.md
@@ -77,11 +77,11 @@ juju integrate grafana-agent-k8s opensearch:metrics-endpoint
 
 After this is complete, Grafana will show the new dashboard `Charmed OpenSearch` and will allow access to Charmed OpenSearch logs on Loki.
 
-### Extend to Large Deployments
+### Extend to large deployments
 
 Large deployments run across multiple juju applications. Connect all the units of each application to grafana-agent, as explained above, and the dashboard will be able to summarize the entire cluster.
 
-### Connect Multiple Clusters
+### Connect multiple clusters
 
 It is possible to have the same COS and dashboard for multiple deployments. The dashboard provides selectors to filter which cluster to watch at the time.
 

--- a/docs/how-to/h-monitoring.md
+++ b/docs/how-to/h-monitoring.md
@@ -16,11 +16,11 @@ Prometheus metrics are automatically installed as an OpenSearch plugin: [The Pro
 
 The meaning of the metrics collected can be found in the upstream documentation:
 
-* [indices stats metrics](https://opensearch.org/docs/latest/api-reference/index-apis/stats/)
-* [nodes_stats_metrics](https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-stats/)
-* [cluster_stats_metrics](https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/)
+* [`indices stats metrics`](https://opensearch.org/docs/latest/api-reference/index-apis/stats/)
+* [`nodes_stats_metrics`](https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-stats/)
+* [`cluster_stats_metrics`](https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/)
 
-## Alert Rules
+## Alert rules
 The charm deploys a pre-configured set of Prometheus alert rules by default.
 
 To ensure you are referencing the latest default alert rules, check the source file of alert definitions in the repository’s [prometheus_alerts.yaml](https://github.com/canonical/opensearch-operator/blob/2/edge/src/alert_rules/prometheus/prometheus_alerts.yaml) file.

--- a/docs/how-to/h-rotate-tls-ca-certificates.md
+++ b/docs/how-to/h-rotate-tls-ca-certificates.md
@@ -32,7 +32,9 @@ This will automatically generate a new private key and regenerate the certificat
 
 For more information on the different approaches to update the key please refer to the ["Update keys" section of How to enable TLS encryption](https://charmhub.io/opensearch/docs/h-enable-tls#update-keys).
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## Rotation of CA certificates
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 The CA certificate is used to sign the TLS certificates. The CA certificate is provided to the OpenSearch cluster by the operator you are using to provide the certificates. In this section, we will describe the process of rotating the CA certificate using the [`self-signed-certificates` operator](https://charmhub.io/self-signed-certificates) and the [`manual-tls` operator](https://charmhub.io/manual-tls-certificates).
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,4 +1,6 @@
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 # Charmed Wazuh Indexer Documentation
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 The [Wazuh Indexer](https://documentation.wazuh.com/current/user-manual/wazuh-indexer/index.html) is a real-time,
 full-text search and analytics engine for security data based on [OpenSearch](http://opensearch.org/).
 Consequently, this charm is a Charmed [OpenSearch](https://github.com/canonical/opensearch-operator) fork.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -20,5 +20,5 @@ While this tutorial intends to guide you as you deploy Charmed OpenSearch for th
 | 3. [**Enable TLS encryption**](/t/9718) | Enable security in your deployment by integrating with a TLS certificates operator
 | 4. [**Integrate with a client application**](/t/9714) | Learn how to integrate a client app with OpenSearch and manage users
 | 5. [**Manage passwords**](/t/9728) | Learn about password management and rotation
-| 6. [**Scale horizontally**](/t/9720) | Scale your application by adding or removing juju units
-| 7. [**Clean up the environment**](/t/9726) | Remove your OpenSearch deployment and juju to free your machine's resources
+| 6. [**Scale horizontally**](/t/9720) | Scale your application by adding or removing Juju units
+| 7. [**Clean up the environment**](/t/9726) | Remove your OpenSearch deployment and Juju to free your machine's resources

--- a/docs/tutorial/t-clean-up.md
+++ b/docs/tutorial/t-clean-up.md
@@ -53,7 +53,7 @@ To uninstall Juju, enter:
 sudo snap remove lxd --purge
 ```
 
-## Reset the Kernel parameters
+## Reset the kernel parameters
 >**Warning:** In the following command, use the values you saved during step 1 -> Get default values.
 
 If you did not save those values, use the second reset option.

--- a/terraform/charm/README.md
+++ b/terraform/charm/README.md
@@ -15,7 +15,7 @@ deployment onto any Kubernetes environment managed by [Juju][Juju].
   the Juju application name.
 - **versions.tf** - Defines the Terraform provider version.
 
-## Using wazuh-indexer base module in higher level modules
+## Using `wazuh-indexer` base module in higher level modules
 
 If you want to use `wazuh-indexer` base module as part of your Terraform module, import it
 like shown below:

--- a/terraform/charm/large_deployment/README.md
+++ b/terraform/charm/large_deployment/README.md
@@ -1,11 +1,13 @@
-# Terraform module for opensearch-operator
+# Terraform module for OpenSearch operator
 
 This is a Terraform module facilitating the deployment of the OpenSearch charm with [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## API
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 ### Inputs
 The module offers the following configurable inputs:
@@ -26,9 +28,9 @@ When applied, the module exports the following outputs:
 | `app_name`                                     | Application name                                                  |
 | `provides`                                     | Map of `provides` endpoints                                       |
 | `requires`                                     | Map of `requires` endpoints                                       |
-| `certificates_offer_url`                       | Offer url of the tls provider if cross-model deployments          |
-| `peer_cluster_orchestrator_main_offer_url`     | Offer url of the main orchestrator if cross-model deployments     |
-| `peer_cluster_orchestrator_failover_offer_url` | Offer url of the failover orchestrator if cross-model deployments |
+| `certificates_offer_url`                       | Offer URL of the TLS provider if cross-model deployments          |
+| `peer_cluster_orchestrator_main_offer_url`     | Offer URL of the main orchestrator if cross-model deployments     |
+| `peer_cluster_orchestrator_failover_offer_url` | Offer URL of the failover orchestrator if cross-model deployments |
 
 
 ## Usage

--- a/terraform/charm/simple_deployment/README.md
+++ b/terraform/charm/simple_deployment/README.md
@@ -1,11 +1,13 @@
-# Terraform module for opensearch-operator
+# Terraform module for OpenSearch operator
 
 This is a Terraform module facilitating the deployment of the OpenSearch charm with [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## API
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 ### Inputs
 The module offers the following configurable inputs:
@@ -21,7 +23,7 @@ The module offers the following configurable inputs:
 | `revision`    | number      | Revision number of the charm name                         | False      |
 | `units`       | number      | Number of units to be deployed                            | False      |
 | `constraints` | string      | Machine constraints for the charm                         | False      |
-| `storage`     | map(string) | Storage description, must follow the juju provider schema | False      |
+| `storage`     | map(string) | Storage description, must follow the Juju provider schema | False      |
 | `expose`      | bool        | Expose block, if set to true, opens to anyone's access    | False      |
 
 

--- a/terraform/product/large_deployment/README.md
+++ b/terraform/product/large_deployment/README.md
@@ -1,11 +1,13 @@
-# Terraform module for opensearch-operator
+# Terraform module for OpenSearch operator
 
 This is a Terraform module facilitating the deployment of the OpenSearch charm with [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## API
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 ### Inputs
 The module offers the following configurable inputs:

--- a/terraform/product/simple_deployment/README.md
+++ b/terraform/product/simple_deployment/README.md
@@ -1,11 +1,13 @@
-# Terraform module for opensearch-operator
+# Terraform module for OpenSearch operator
 
 This is a Terraform module facilitating the deployment of the OpenSearch charm with [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## API
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 ### Inputs
 The module offers the following configurable inputs:


### PR DESCRIPTION
Applicable ticket: ISD-3949

## Issue

There's a bug in operator-workflows that points to an older version of the Canonical Vale style checks. Therefore some of the checks will be missed in the GitHub CI.

## Solution

Ran Vale checks locally and fixed the errors.

## Checklist
- [X] I have added or updated any relevant documentation.
- [ ] The [changelog](../docs/changelog-fork.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

Since this PR contains only trivial doc changes, I don't think I need to update the changelog.
