### PR TITLE
chore(terraform): update terraform and juju provider versions (charmkeeper)

### DIFF
--- a/terraform/charm/large_deployment/versions.tf
+++ b/terraform/charm/large_deployment/versions.tf
@@ -2,12 +2,12 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = "~> 1.12"
 
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.1.1"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/charm/simple_deployment/versions.tf
+++ b/terraform/charm/simple_deployment/versions.tf
@@ -2,12 +2,12 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = "~> 1.12"
 
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.1.1"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/charm/versions.tf
+++ b/terraform/charm/versions.tf
@@ -2,11 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.1.1"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/product/large_deployment/versions.tf
+++ b/terraform/product/large_deployment/versions.tf
@@ -2,12 +2,12 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = "~> 1.12"
 
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.1.1"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/product/simple_deployment/versions.tf
+++ b/terraform/product/simple_deployment/versions.tf
@@ -2,12 +2,12 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = "~> 1.12"
 
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.1.1"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/product/versions.tf
+++ b/terraform/product/versions.tf
@@ -2,11 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.1.1"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
## Changes
- Updated `required_version` to `~> 1.12` in all `versions.tf` files
- Updated juju provider version to `~> 1.0` in all `versions.tf` files
### Files modified:
- `terraform/product/versions.tf`
- `terraform/product/large_deployment/versions.tf`
- `terraform/product/simple_deployment/versions.tf`
- `terraform/charm/versions.tf`
- `terraform/charm/large_deployment/versions.tf`
- `terraform/charm/simple_deployment/versions.tf`