### PR TITLE
Pin setuptools <82 for jproperties

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
     name: Build charm | ${{ matrix.path }}
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v32.1.0
     with:
-      cache: 'false'
+      cache: false
       path-to-charm-directory: ${{ matrix.path }}
 
   integration-test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,6 +170,7 @@ jobs:
     name: Build charm | ${{ matrix.path }}
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v32.1.0
     with:
+      cache: 'false'
       path-to-charm-directory: ${{ matrix.path }}
 
   integration-test:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -100,7 +100,7 @@ jobs:
       # https://github.com/canonical/charmcraft/issues/2130 fixed
       - run: |
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
       - name: Download packed charm(s)
         timeout-minutes: 5
         uses: actions/download-artifact@v4

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -58,7 +58,12 @@ parts:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source
       - pkg-config  # Needed to build Python dependencies with Rust from source
+    build-environments:
+      - PIP_CONSTRAINT: ${CRAFT_PART_BUILD}/pip-constraints.txt
     override-build: |
+      # Pin setuptools <82 for `jproperties`
+      echo 'setuptools<82' > "${CRAFT_PART_BUILD}/pip-constraints.txt"
+
       # Workaround for https://github.com/canonical/charmcraft/issues/2068
       # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source
       if [[ "$CRAFT_PLATFORM" == ubuntu@20.04:* || "$CRAFT_PLATFORM" == ubuntu@22.04:* ]]

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -58,7 +58,7 @@ parts:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source
       - pkg-config  # Needed to build Python dependencies with Rust from source
-    build-environments:
+    build-environment:
       - PIP_CONSTRAINT: ${CRAFT_PART_BUILD}/pip-constraints.txt
     override-build: |
       # Pin setuptools <82 for `jproperties`

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -61,8 +61,23 @@ parts:
     build-environment:
       - PIP_CONSTRAINT: ${CRAFT_PART_BUILD}/pip-constraints.txt
     override-build: |
-      # Pin setuptools <82 for `jproperties`
-      echo 'setuptools<82' > "${CRAFT_PART_BUILD}/pip-constraints.txt"
+      # Constraints for isolated Python build environments (see
+      # `build-environment: PIP_CONSTRAINT` above).
+      #
+      # `jproperties` is built from source (the poetry plugin installs with
+      # `--no-binary=:all:`); its `setuptools_scm` 3.x build dependency imports
+      # `pkg_resources`, which setuptools >=82 removed, so pin setuptools <82.
+      #
+      # That pin then breaks `types-psutil`/`types-setuptools` (build
+      # dependencies of `mypy`, pulled in when `charset-normalizer` builds its
+      # mypyc speedups from source): their newest releases require
+      # setuptools >=82. Pin them to the newest releases that still build with
+      # setuptools <82.
+      cat > "${CRAFT_PART_BUILD}/pip-constraints.txt" <<'CONSTRAINTS'
+      setuptools<82
+      types-psutil<7.2.2.20260402
+      types-setuptools<82.0.0.20260402
+      CONSTRAINTS
 
       # Workaround for https://github.com/canonical/charmcraft/issues/2068
       # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -61,23 +61,11 @@ parts:
     build-environment:
       - PIP_CONSTRAINT: ${CRAFT_PART_BUILD}/pip-constraints.txt
     override-build: |
-      # Constraints for isolated Python build environments (see
-      # `build-environment: PIP_CONSTRAINT` above).
-      #
-      # `jproperties` is built from source (the poetry plugin installs with
-      # `--no-binary=:all:`); its `setuptools_scm` 3.x build dependency imports
-      # `pkg_resources`, which setuptools >=82 removed, so pin setuptools <82.
-      #
-      # That pin then breaks `types-psutil`/`types-setuptools` (build
-      # dependencies of `mypy`, pulled in when `charset-normalizer` builds its
-      # mypyc speedups from source): their newest releases require
-      # setuptools >=82. Pin them to the newest releases that still build with
-      # setuptools <82.
-      cat > "${CRAFT_PART_BUILD}/pip-constraints.txt" <<'CONSTRAINTS'
+      cat > "${CRAFT_PART_BUILD}/pip-constraints.txt" <<'EOF'
       setuptools<82
       types-psutil<7.2.2.20260402
       types-setuptools<82.0.0.20260402
-      CONSTRAINTS
+      EOF
 
       # Workaround for https://github.com/canonical/charmcraft/issues/2068
       # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source

--- a/docs/changelog-fork.md
+++ b/docs/changelog-fork.md
@@ -9,7 +9,11 @@ Each revision is versioned by the date of the revision.
 ## 2026-06-15
 
 ### Fixed
-- Pin setuptools <82 for `jproperties` to fix charmcraft pack.
+- Pin setuptools <82 for `jproperties` to fix charmcraft pack. Also pin
+  `types-psutil`/`types-setuptools` to the newest releases that still build
+  with setuptools <82 (their build dependencies of `mypy`, pulled when
+  `charset-normalizer` builds from source, otherwise require setuptools >=82
+  and conflict with the pin above).
 
 ## 2025-08-22
 

--- a/docs/changelog-fork.md
+++ b/docs/changelog-fork.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-15
+
+### Fixed
+- Pin setuptools <82 for `jproperties` to fix charmcraft pack.
+
 ## 2025-08-22
 
 ### Updated


### PR DESCRIPTION
## Issue

`charmcraft pack` failed.

## Solution

Pin setuptools <82 for `jproperties` in `charmcraft.yaml`

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] The [changelog](../docs/changelog-fork.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

