### PR TITLE
Align with the other request to avoid timeout failures

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -271,7 +271,9 @@ class BackupManager:
         """Returns a mapping of snapshot ids / state."""
         # Using the original request method, as we want to raise an http exception if we
         # cannot get the snapshot list.
-        response = self.charm.opensearch.request("GET", f"_snapshot/{self.repository}/_all")
+        response = self.charm.opensearch.request(
+            "GET", f"_snapshot/{self.repository}/_all", retries=6, timeout=10
+        )
         return {
             snapshot["snapshot"].upper(): {
                 "state": snapshot["state"],


### PR DESCRIPTION
The "list-backups" actions was missing some retries. This PR aligns with the other queries in the library adopting 6 retries and a 10s timeout.

Ref: https://warthogs.atlassian.net/browse/ISD-6162